### PR TITLE
Issue #32: Fix docker logs not persisted

### DIFF
--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -15,8 +15,7 @@ services:
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs/tomcat:/var/log/wisdom-core/tomcat
-      - ./logs/app:/var/log/wisdom-core/app
+      - ./logs:/app/logs
     ports:
       - 9999:9000
 

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs:/app/logs
+      - ./logs/tomcat:/var/log/wisdom-core/tomcat
+      - ./logs/app:/var/log/wisdom-core/app
     ports:
       - 9999:9000
 

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -16,8 +16,7 @@ services:
       - server.tomcat.accesslog.directory=./
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs/tomcat:/var/log/wisdom-core/tomcat
-      - ./logs/app:/var/log/wisdom-core/app
+      - ./logs:/var/log/wisdom-core
     ports:
       - 9999:9000
 

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - spring.data.mongodb.uri=mongodb://root:password@mongo:27017
       - spring.data.mongodb.database=wisdom
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
-      - server.tomcat.accesslog.directory=/var/log/wisdom-core/tomcat/access-logs
+      - server.tomcat.accesslog.directory=./
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
       - ./logs/tomcat:/var/log/wisdom-core/tomcat/access-logs

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs/tomcat/:/var/log/wisdom-core/tomcat
-      - ./logs/app/:/var/log/wisdom-core/app
+      - ./logs/tomcat:/var/log/wisdom-core/tomcat
+      - ./logs/app:/var/log/wisdom-core/app
     ports:
       - 9999:9000
 

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - spring.data.mongodb.uri=mongodb://root:password@mongo:27017
       - spring.data.mongodb.database=wisdom
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
-      - server.tomcat.accesslog.directory=./access-logs
+      - server.tomcat.accesslog.directory=/var/log/wisdom-core/tomcat/access-logs
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
       - ./logs/tomcat:/var/log/wisdom-core/tomcat/access-logs

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs/tomcat:/var/log/wisdom-core/tomcat/logs
+      - ./logs/tomcat/:/var/log/wisdom-core/tomcat
       - ./logs/app/:/var/log/wisdom-core/app
     ports:
       - 9000:9000

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./logs/tomcat/:/var/log/wisdom-core/tomcat
       - ./logs/app/:/var/log/wisdom-core/app
     ports:
-      - 9000:9000
+      - 9999:9000
 
   mongo:
     image: mongo
@@ -31,5 +31,7 @@ services:
       - type: volume
         source: mongo-data
         target: /data/db
+    ports:
+      - 9998:27017
 volumes:
   mongo-data:

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - spring.data.mongodb.uri=mongodb://root:password@mongo:27017
       - spring.data.mongodb.database=wisdom
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
-      - server.tomcat.accesslog.directory=./
+      - server.tomcat.accesslog.directory=/var/log/wisdom-core/tomcat
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
       - ./logs/tomcat:/var/log/wisdom-core/tomcat

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - spring.data.mongodb.uri=mongodb://root:password@mongo:27017
       - spring.data.mongodb.database=wisdom
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
-      - server.tomcat.accesslog.directory=./
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
       - ./logs:/var/log/wisdom-core

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - server.tomcat.accesslog.directory=./
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs/tomcat:/var/log/wisdom-core/tomcat/access-logs
+      - ./logs/tomcat:/var/log/wisdom-core/tomcat
       - ./logs/app:/var/log/wisdom-core/app
     ports:
       - 9999:9000

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -13,10 +13,10 @@ services:
       - spring.data.mongodb.uri=mongodb://root:password@mongo:27017
       - spring.data.mongodb.database=wisdom
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
-      - server.tomcat.accesslog.directory=/var/log/wisdom-core/tomcat
+      - server.tomcat.accesslog.directory=./access-logs
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
-      - ./logs/tomcat:/var/log/wisdom-core/tomcat
+      - ./logs/tomcat:/var/log/wisdom-core/tomcat/access-logs
       - ./logs/app:/var/log/wisdom-core/app
     ports:
       - 9999:9000

--- a/deploy/prod/instance/docker-compose.yml
+++ b/deploy/prod/instance/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - spring.data.mongodb.uri=mongodb://root:password@mongo:27017
       - spring.data.mongodb.database=wisdom
       - server.tomcat.basedir=/var/log/wisdom-core/tomcat
+      - server.tomcat.accesslog.directory=./
       - logging.file.path=/var/log/wisdom-core/app
     volumes:
       - ./logs/tomcat:/var/log/wisdom-core/tomcat

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ logging.file.path=./logs/app
 # Taken from https://www.baeldung.com/spring-boot-embedded-tomcat-logs
 server.tomcat.accesslog.enabled=true
 server.tomcat.basedir=logs/tomcat
-server.tomcat.accesslog.directory=/
+server.tomcat.accesslog.directory=./


### PR DESCRIPTION
Closes #32

Cause: server.tomcat.accesslog.directory uses the value `/` which is kind of a reserved folder name for linux-based OSes. Our intention is to use parent dir (`./`) in Windows.

Fix: Use `./` instead of `/` to keep things cross-platform-compatible.